### PR TITLE
add support to report a mouse events via stdin with esc-sequences:

### DIFF
--- a/src/daemon/do_selection.c
+++ b/src/daemon/do_selection.c
@@ -19,9 +19,46 @@
  *
  ********/
 
+#include <fcntl.h>		    /* O_WRONLY */
+#include <linux/kd.h>		    /* KDGKBLED */
+#include <unistd.h>		    /* close()  */
+
 #include "headers/message.h"        /* messaging in gpm */
 #include "headers/daemon.h"         /* daemon internals */
 #include "headers/gpmInt.h"         /* daemon internals */
+
+/*-------------------------------------------------------------------*/
+static void do_report_mouse(int fd, Gpm_Event *event, int x, int y)
+{
+   unsigned char buf[6*sizeof(short)];
+   unsigned short *arg = (unsigned short *)buf + 1;
+
+   const int type = event->type & (GPM_DOWN|GPM_UP);
+   int buttons = event->buttons;
+
+   if (type==GPM_UP)
+      buttons = 0;
+
+   if (type == 0 && buttons == 0)
+       return;
+
+   buf[sizeof(short)-1] = 2;  /* set selection */
+
+   arg[0]=arg[2]=(unsigned short)x;
+   arg[1]=arg[3]=(unsigned short)y;
+
+   arg[4] =16; /* report mouse case */
+   if (event->modifiers & 3)        arg[4] |= 4;  /* shift */
+   if (event->modifiers & 8)        arg[4] |= 8;  /* alt */
+
+   if (buttons & GPM_B_RIGHT)       arg[4] |= 2;
+   else if (buttons & GPM_B_MIDDLE) arg[4] |= 1;
+   else if (buttons & GPM_B_LEFT)   arg[4] |= 0;
+   else                             arg[4] |= 3;  /* UP */
+
+   if (ioctl(fd, TIOCLINUX, buf+sizeof(short)-1) < 0)
+      gpm_report(GPM_PR_OOPS,GPM_MESS_IOCTL_TIOCLINUX);
+}
 
 /*-------------------------------------------------------------------*/
 int do_selection(Gpm_Event *event)  /* returns 0, always */
@@ -29,48 +66,68 @@ int do_selection(Gpm_Event *event)  /* returns 0, always */
    static int x1=1, y1=1, x2, y2;
 #define UNPOINTER() 0
 
+   int fd;
+   unsigned char report_mouse = 7;
+
+   if ((fd=open_console(O_WRONLY))<0)
+      gpm_report(GPM_PR_OOPS,GPM_MESS_OPEN_CON);
+
+   if (ioctl(fd, TIOCLINUX, &report_mouse) < 0)
+      gpm_report(GPM_PR_OOPS,GPM_MESS_IOCTL_TIOCLINUX);
+
+   if (event->modifiers & 4) /* Ctrl, keep it for selection/paste */
+      report_mouse = 0;
+
+   if (report_mouse) {
+      char kbd_flag = 0;
+      ioctl(fd,KDGKBLED,&kbd_flag);
+      if( kbd_flag & 1 )     /* Scroll Lock */
+         report_mouse = 0;
+   }
+
    x2=event->x; y2=event->y;
+   if (x2<1) x2=1; else if (x2>maxx) x2=maxx;
+   if (y2<1) y2=1; else if (y2>maxy) y2=maxy;
+
+   if (report_mouse)
+      do_report_mouse(fd,event,x2,y2);
+
    switch(GPM_BARE_EVENTS(event->type)) {
       case GPM_MOVE:
-         if (x2<1) x2++; else if (x2>maxx) x2--;
-         if (y2<1) y2++; else if (y2>maxy) y2--;
-         selection_copy(x2,y2,x2,y2,3); /* just highlight pointer */
-         return 0;
+      default:
+         selection_copy(fd,x2,y2,x2,y2,3); /* just highlight pointer */
+         break;
 
       case GPM_DRAG:
-         if (event->buttons==GPM_B_LEFT) {
-            if (event->margin) /* fix margins */
-               switch(event->margin) {
-                  case GPM_TOP: x2=1; y2++; break;
-                  case GPM_BOT: x2=maxx; y2--; break;
-                  case GPM_RGT: x2--; break;
-                  case GPM_LFT: y2<=y1 ? x2++ : (x2=maxx, y2--); break;
-               }
-            selection_copy(x1,y1,x2,y2,event->clicks);
-            if (event->clicks>=opt_ptrdrag && !event->margin) /* pointer */
-               selection_copy(x2,y2,x2,y2,3);
-         } /* if */
-         return 0;
+         if (event->buttons==GPM_B_LEFT && !report_mouse)
+            selection_copy(fd,x1,y1,x2,y2,event->clicks);
+         if ((event->clicks>=opt_ptrdrag && !event->margin) || report_mouse)
+            selection_copy(fd,x2,y2,x2,y2,3); /* pointer */
+         break;
 
       case GPM_DOWN:
+         if (!report_mouse)
          switch (event->buttons) {
             case GPM_B_LEFT:
-               x1=x2; y1=y2;
-               selection_copy(x1,y1,x2,y2,event->clicks); /* start selection */
-               return 0;
+	       x1=x2; y1=y2;
+	       selection_copy(fd,x1,y1,x2,y2,event->clicks);  /*  start selection */
+               break;
 
             case GPM_B_MIDDLE:
-               selection_paste();
-               return 0;
+               selection_paste(fd);
+               break;
 
             case GPM_B_RIGHT:
                if ((which_mouse->opt_three)==1)
-                  selection_copy(x1,y1,x2,y2,event->clicks);
-               else
-                  selection_paste();
-               return 0;
+	          selection_copy(fd,x1,y1,x2,y2,event->clicks);
+	       else
+	          selection_paste(fd);
+	       break;
          }
+         break;
+
    } /* switch above */
+
+   close(fd);
    return 0;
 }
-

--- a/src/daemon/processmouse.c
+++ b/src/daemon/processmouse.c
@@ -204,7 +204,6 @@ int processMouse(int fd, Gpm_Event *event, Gpm_Type *type, int kd_mode)
     */
    if (stat.v_active != j)
       get_console_size(event);
-   close(i);
 
    event->vc = stat.v_active;
 
@@ -212,6 +211,12 @@ int processMouse(int fd, Gpm_Event *event, Gpm_Type *type, int kd_mode)
       event->type = (event->buttons ? GPM_DRAG : GPM_MOVE);
    else
       event->type = (event->buttons > oldB ? GPM_DOWN : GPM_UP);
+
+   if (ioctl(i,TIOCGWINSZ,&win)==0) {
+      maxx=win.ws_col;
+      maxy=win.ws_row;
+   }
+   close(i);
 
    switch(event->type) {                /* now provide the cooked bits */
       case GPM_DOWN:

--- a/src/daemon/selection_copy.c
+++ b/src/daemon/selection_copy.c
@@ -27,7 +27,7 @@
 #include "headers/message.h"        /* messaging in gpm */
 #include "headers/daemon.h"         /* daemon internals */
 
-void selection_copy(int x1, int y1, int x2, int y2, int mode)
+void selection_copy(int fd, int x1, int y1, int x2, int y2, int mode)
 {
 /*
  * The approach in "selection" causes a bus error when run under SunOS 4.1
@@ -35,7 +35,6 @@ void selection_copy(int x1, int y1, int x2, int y2, int mode)
  */
    unsigned char buf[6*sizeof(short)];
    unsigned short *arg = (unsigned short *)buf + 1;
-   int fd;
 
    buf[sizeof(short)-1] = 2;  /* set selection */
 
@@ -45,13 +44,10 @@ void selection_copy(int x1, int y1, int x2, int y2, int mode)
    arg[3]=(unsigned short)y2;
    arg[4]=(unsigned short)mode;
 
-   if ((fd=open_console(O_WRONLY))<0)
-      gpm_report(GPM_PR_OOPS,GPM_MESS_OPEN_CON);
    /* FIXME: should be replaced with string constant (headers/message.h) */
    gpm_report(GPM_PR_DEBUG,"ctl %i, mode %i",(int)*buf, arg[4]);
    if (ioctl(fd, TIOCLINUX, buf+sizeof(short)-1) < 0)
      gpm_report(GPM_PR_OOPS,GPM_MESS_IOCTL_TIOCLINUX);
-   close(fd);
 
    if (mode < 3) {
       opt_aged = 0;

--- a/src/daemon/selection_paste.c
+++ b/src/daemon/selection_paste.c
@@ -26,10 +26,9 @@
 #include "headers/message.h"        /* messaging in gpm */
 #include "headers/daemon.h"         /* daemon internals */
 
-void selection_paste(void)
+void selection_paste(int fd)
 {
    char c=3;
-   int fd;
 
    if (!opt_aged && (0 != opt_age_limit) &&
       (last_selection_time + opt_age_limit < time(0))) {
@@ -41,9 +40,7 @@ void selection_paste(void)
       return;
    }
 
-   fd=open_console(O_WRONLY);
    if(ioctl(fd, TIOCLINUX, &c) < 0)
       gpm_report(GPM_PR_OOPS,GPM_MESS_IOCTL_TIOCLINUX);
-   close(fd);
 }
 

--- a/src/headers/daemon.h
+++ b/src/headers/daemon.h
@@ -211,8 +211,8 @@ int processMouse(int fd, Gpm_Event *event, Gpm_Type *type, int kd_mode);
 int processRequest(Gpm_Cinfo *ci, int vc);
 int processSpecial(Gpm_Event *event);
 
-void selection_copy(int x1, int y1, int x2, int y2, int mode);
-void selection_paste(void);
+void selection_copy(int fd, int x1, int y1, int x2, int y2, int mode);
+void selection_paste(int fd);
 
 void startup(int argc, char **argv);
 


### PR DESCRIPTION
an xterm-like mouse reporting. A bugs reports to seyko2@gmail.com
# 

getc()
{
    stty raw
    dd bs=1 count=1 2>/dev/null
    stty cooked
}

handle_mouse()
{
    local c
    c="`getc`"
    [ "$c" = "[" ] || return
    c="`getc`"
    [ "$c" = "M" ] || return
    b="`getc`"
    x="`getc`"
    y="`getc`"
    b=`printf "%u" "'$b"`
    x=`printf "%u" "'$x"`
    y=`printf "%u" "'$y"`
    b=$(($b - 32))
    x=$(($x - 32))
    y=$(($y - 32))
    echo "$b $x $y"
}

stty -echo
printf '\033[?1000h'
ESC="`printf '\033'`"
while true ; do
    c="`getc`"
    if [ "$c" = "$ESC" ] ; then
        handle_mouse
    fi
    if [ "$c" = "q" ] ; then
        break
    fi
done
printf '\033[?1000l'
stty echo
# echo
