### PR TITLE
src/Makefile.in: Really install unversioned solibrary

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -115,6 +115,7 @@ install:	check
 	if test "x@SHLIB@" != "x" ; then \
 		$(INSTALL_DATA) -m 755 lib/libgpm.so.@abi_full@ $(libdir)/libgpm.so.@abi_full@	;	\
 		cd $(libdir) && $(LN_S) -f libgpm.so.@abi_full@ libgpm.so.@abi_lev@ 					;	\
+		cd $(libdir) && $(LN_S) -f libgpm.so.@abi_full@ libgpm.so 					;	\
       echo "WARNING: We installed a lib, you should now call ldconfig" 						; 	\
       echo "f.i.: ldconfig -n -l $(libdir)/libgpm.so.@abi_full@" 								;	\
       echo "Or to update everything just type ldconfig"											;	\


### PR DESCRIPTION
This commit is a follow-up to
https://github.com/telmich/gpm/commit/06b00d53d8bd513ad5d262dc94a016c6fbf2d3aa
which created libgpm.so but failed to include it in the install target.