### PR TITLE
fix building w/newer glibc

### DIFF
--- a/src/daemon/open_console.c
+++ b/src/daemon/open_console.c
@@ -24,6 +24,10 @@
 #include <sys/types.h>              /* major()           */
 #include <sys/ioctl.h>              /* ioctl             */
 
+#ifdef HAVE_SYS_SYSMACROS_H
+#include <sys/sysmacros.h>          /* major() w/newer glibc */
+#endif
+
 /* Linux specific (to be outsourced in gpm2 */
 #include <linux/serial.h>           /* for serial console check */
 #include <asm/ioctls.h>            /* for serial console check */


### PR DESCRIPTION
Linux C libraries are looking to disentangle sysmacros.h from the
sys/types.h include, so make sure we pull in the header when it is
found.