### PR TITLE
For absolute positioned devices on /dev/input/eventX

### DIFF
--- a/src/headers/message.h
+++ b/src/headers/message.h
@@ -208,6 +208,7 @@
 #define GPM_MESS_IOCTL_KDGETMODE    "ioctl(KDGETMODE)"
 #define GPM_MESS_IOCTL_TIOCLINUX    "ioctl(TIOCLINUX)"
 #define GPM_MESS_IOCTL_TIOCSTI      "%s: ioctl(TIOCSTI): %s"
+#define GPM_MESS_IOCTL_EVIOCGABS    "ioctl(EVIOCGABS(%s): %s"
 
 /* debug */
 #define GPM_MESS_PEER_SCK_UID       "peer socket uid = %d"


### PR DESCRIPTION
Only tested with the Raspberry Pi "Official Touchscreen"(ft5406)
but may work with other touch screens and devices that report position
information in absolute coordiantes.

The options reverseX, reverseY, swapXY can be used to deal with screen
rotation. The fake3buttons uses the count of touchpoints to fake the
behavior of the 3 button mouse, with limited success.