### PR TITLE
Gpm musl

### DIFF
--- a/src/daemon/gpm.c
+++ b/src/daemon/gpm.c
@@ -29,7 +29,7 @@
 #include <signal.h>        /* SIGPIPE */
 #include <time.h>          /* time() */
 #include <sys/param.h>
-#include <sys/fcntl.h>     /* O_RDONLY */
+#include <fcntl.h>         /* O_RDONLY */
 #include <sys/wait.h>      /* wait()   */
 #include <sys/stat.h>      /* mkdir()  */
 #include <sys/time.h>      /* timeval */

--- a/src/daemon/old_main.c
+++ b/src/daemon/old_main.c
@@ -25,6 +25,7 @@
 #include <signal.h>                 /* guess again       */
 #include <errno.h>                  /* guess again       */
 #include <unistd.h>                 /* unlink            */
+#include <string.h>                 /* strcpy, bzero     */
 #include <sys/stat.h>               /* chmod             */
 
 #include <linux/kd.h>               /* linux hd*         */

--- a/src/lib/liblow.c
+++ b/src/lib/liblow.c
@@ -33,7 +33,7 @@
 #include <sys/types.h>     /* socket() */
 #include <sys/socket.h>    /* socket() */
 #include <sys/un.h>        /* struct sockaddr_un */
-#include <sys/fcntl.h>     /* O_RDONLY */
+#include <fcntl.h>     /* O_RDONLY */
 #include <sys/stat.h>      /* stat() */
 
 #ifdef  SIGTSTP         /* true if BSD system */
@@ -173,7 +173,7 @@ static void gpm_suspend_hook (int signum)
   /* Reincarnation. Prepare for another death early. */
   sigemptyset(&sa.sa_mask);
   sa.sa_handler = gpm_suspend_hook;
-  sa.sa_flags = SA_NOMASK;
+  sa.sa_flags = SA_NODEFER;
   sigaction (SIGTSTP, &sa, 0);
 
   /* Pop the gpm stack by closing the useless connection */
@@ -364,7 +364,7 @@ int Gpm_Open(Gpm_Connect *conn, int flag)
 
          /* if signal was originally ignored, job control is not supported */
          if (gpm_saved_suspend_hook.sa_handler != SIG_IGN) {
-            sa.sa_flags = SA_NOMASK;
+            sa.sa_flags = SA_NODEFER;
             sa.sa_handler = gpm_suspend_hook;
             sigaction(SIGTSTP, &sa, 0);
          }

--- a/src/lib/liblow.c
+++ b/src/lib/liblow.c
@@ -29,11 +29,12 @@
 #include <string.h>        /* strncmp */
 #include <unistd.h>        /* select(); */
 #include <errno.h>
+#include <fcntl.h>         /* O_RDONLY */
+
 #include <sys/time.h>      /* timeval */
 #include <sys/types.h>     /* socket() */
 #include <sys/socket.h>    /* socket() */
 #include <sys/un.h>        /* struct sockaddr_un */
-#include <fcntl.h>     /* O_RDONLY */
 #include <sys/stat.h>      /* stat() */
 
 #ifdef  SIGTSTP         /* true if BSD system */


### PR DESCRIPTION
These changes enable compilation of gpm using gcc 4.6.4 and the musl C library 1.1.20.
These changed don't break compilation with gcc/glibc.