### PR TITLE
src/headers/daemon.h: avoid redefinition of 'last_selection_time'

### DIFF
--- a/src/headers/daemon.h
+++ b/src/headers/daemon.h
@@ -180,7 +180,7 @@ extern struct mouse_features  mouse_table[3],
 extern Gpm_Type         mice[];
 extern Gpm_Type         *repeated_type;
 
-time_t                  last_selection_time;
+extern time_t           last_selection_time;
 
 
 


### PR DESCRIPTION
Noticed build failure on gcc-10 as:

```
gcc  -L/home/slyfox/dev/git/gpm/src  -o gpm mice.o ... report.o tools.o   -lm
ld: twiddler.o:gpm/src/headers/daemon.h:183:
  multiple definition of `last_selection_time'; mice.o:gpm/src/headers/daemon.h:183: first defined here
ld: synaptics.o:git/gpm/src/headers/daemon.h:183:
  multiple definition of `last_selection_time'; mice.o:git/gpm/src/headers/daemon.h:183: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.