### PR TITLE
configure.ac: add support for static-only configuration

### DIFF
--- a/Makefile.include.in
+++ b/Makefile.include.in
@@ -56,7 +56,7 @@ MAKEINFO          = @MAKEINFO@
 TEXI2HTML         = texi2html
 STRIP             = -s
 
-AR                = ar
+AR                = @AR@
 ETAGS             = etags
 AWK               = awk
 CP                = cp -a

--- a/configure.ac.footer
+++ b/configure.ac.footer
@@ -75,6 +75,9 @@ AC_CHECK_HEADERS(sys/socket.h,,[AC_MSG_ERROR([Required header file missing])])
 
 AC_ARG_ENABLE([static],
 [  --enable-static         build static libraries @<:@default=no@:>@])
+AC_ARG_ENABLE([shared],
+[  --enable-shared         build shared libraries @<:@default=yes@:>@])
+
 
 LIBGPM_A=
 
@@ -131,9 +134,22 @@ No|no|N|n) SHARED_LIBS=-lc ;;
     done
     SHARED_LIBS="$LIBS $TERMLIBS -lc"
     LIBS=$SAVELIBS ;;
-esac    
+esac
+
+LIBGPM_SO=
+LIBGPM_SO_LEV=
+LIBGPM_SO_FULL=
+
+AS_IF([test "x$enable_shared" = "xyes"], [
+        LIBGPM_SO=lib/libgpm.so
+        LIBGPM_SO_LEV=lib/libgpm.so.$abi_lev
+        LIBGPM_SO_FULL=lib/libgpm.so.$abi_full
+])
 
 GPMXTERM=
+AC_SUBST(LIBGPM_SO)
+AC_SUBST(LIBGPM_SO_LEV)
+AC_SUBST(LIBGPM_SO_FULL)
 AC_SUBST(GPMXTERM)
 AC_SUBST(abi_lev)
 AC_SUBST(abi_full)

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -79,7 +79,7 @@ prog/%:	prog/%.o
 #		| $(SED) '\''s/\($*\)\.o\([ :]*\)/\1.o \1.lo\2/g'\'' > $(DEPDIR)/$@'
 
 # Do it all!
-all:	gpm lib/libgpm.so.@abi_lev@ lib/libgpm.so @LIBGPM_A@ $(PROG)
+all:	gpm @LIBGPM_SO@ @LIBGPM_SO_LEV@ @LIBGPM_A@ $(PROG)
 
 gpm:	$(GOBJ)
 	$(CC) @LDFLAGS@ $(LDFLAGS) -o $@ $(GOBJ) @LIBS@ $(LIBS) -lm
@@ -149,14 +149,26 @@ prog/gpm-root.c:	$(srcdir)/prog/gpm-root.y
 	$(YACC) $(YFLAGS) $< && mv y.tab.c prog/gpm-root.c
 
 # gpm-root needs an own rule, because gpm-root.c is not in $(srcdir)
-prog/gpm-root: prog/gpm-root.c lib/libgpm.so.@abi_lev@
+ifneq (@LIBGPM_SO_LEV@,)
+prog/gpm-root: prog/gpm-root.c @LIBGPM_SO_LEV@
 	$(CC) -I. @CPPFLAGS@ $(CPPFLAGS) @CFLAGS@ $(CFLAGS) -c -o $@.o $<
-	$(CC) @LDFLAGS@ $(LDFLAGS) -o $@ $@.o @LIBS@ $(LIBS) lib/libgpm.so.@abi_lev@
+	$(CC) @LDFLAGS@ $(LDFLAGS) -o $@ $@.o @LIBS@ $(LIBS) @LIBGPM_SO_LEV@
+else
+prog/gpm-root: prog/gpm-root.c @LIBGPM_A@
+	$(CC) -I. @CPPFLAGS@ $(CPPFLAGS) @CFLAGS@ $(CFLAGS) -c -o $@.o $<
+	$(CC) @LDFLAGS@ $(LDFLAGS) -o $@ $@.o @LIBS@ $(LIBS) @LIBGPM_A@
+endif
 
 prog/mouse-test:	prog/mouse-test.o mice.o twiddler.o synaptics.o prog/open_console.o
 	$(CC) @LDFLAGS@ $(LDFLAGS) -o $@ $^ @LIBS@ $(LIBS) -lm
 
-$(PROG):	lib/libgpm.so.@abi_lev@
+# If we build both static and shared libraries, favor shared to preserve
+# old behaviour.
+ifneq (@LIBGPM_SO_LEV@,)
+$(PROG):	@LIBGPM_SO_LEV@
+else
+$(PROG):	@LIBGPM_A@
+endif
 
 # Subdirectory lib/
 lib/libgpm.a:	$(LOBJ)


### PR DESCRIPTION
Adjust build system to link binaries to static library if shared is not built.
Also, use @AR@ provided by autoconf instead of unprefixed "ar" to support
cross-compilation.
