### PR TITLE
Makefile.in: guarantee directory creation at install time before file…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,8 @@ Makefile.include: config.status $(srcdir)/Makefile.include.in
 
 install:	check installdirs do-install
 
+do-install: installdirs
+
 install-strip:
 	$(MAKE) INSTALL_PROGRAM='$(INSTALL_PROGRAM) $(STRIP)' install
 


### PR DESCRIPTION
… copy

With help of 'make --shuffle' mode (https://savannah.gnu.org/bugs/index.php?62100)
I found a few missing target dependencies in 'make install' of gpm.

One of the failures is a reference to missing directory:

    $ make install --shuffle
    make -C src dep
    make[1]: Entering directory '/build/gpm/src'
    # make links in srcdir
    make[1]: [Makefile:92: dep] Error 1 (ignored) shuffle=1655759403
    # create dependencies
    for DEPS in `echo *.c */*.c`; do \
    gcc -I. -I /build/gpm/src -I /build/gpm/src/headers -M  -I/build/gpm/src -DHAVE_CONFIG_H -include headers/config.h -Wall -DSYSCONFDIR="\"/etc\"" -DSBINDIR="\"../gpm-unstable-2020-06-17/sbin\"" -D_GNU_SOURCE  $DEPS | \
    sed 's/^\(.*\)\.o\([ :]+\)/\1.o \1.lo\2/g' >> .depend ; done
    make[1]: Leaving directory '/build/gpm/src'
    make[1]: Entering directory '/build/gpm/src'
    make[1]: Nothing to be done for 'all'.
    make[1]: Leaving directory '/build/gpm/src'
    make[1]: Entering directory '/build/gpm/doc'
    make[1]: Nothing to be done for 'all'.
    make[1]: Leaving directory '/build/gpm/doc'
    make[1]: Entering directory '/build/gpm/contrib'
    make[1]: Nothing to be done for 'all'.
    make[1]: Leaving directory '/build/gpm/contrib'
    make[1]: Entering directory '/build/gpm/src'
    install -c gpm ../gpm-unstable-2020-06-17/sbin/gpm
    install: cannot create regular file '../gpm-unstable-2020-06-17/sbin/gpm': No such file or directory

Note that in this case 'gmp' binary installation attempts to copy
the binary before target directory is created. The change adds a depend.