### PR TITLE
Fix compilation with C23-supporting compilers, eg. GCC-15 and Clang-19

### DIFF
--- a/src/headers/gpm.h
+++ b/src/headers/gpm.h
@@ -268,7 +268,14 @@ Gpm_Roi * Gpm_LowerRoi(Gpm_Roi *which, Gpm_Roi *after);
 /* libcurses.c */
 /* #include <curses.h>  Hmm... seems risky */
 
-extern int Gpm_Wgetch();
+/* Window handle is an opaque pointer that Gpm_Wgetch()
+ * passes through to ncurses if it's not null and calls getch
+ * if it's null. Code doesn't care what's inside the handle
+ * as long as it agrees with curses definition.
+*/
+typedef struct _win_st WINDOW;
+
+extern int Gpm_Wgetch(WINDOW *);
 #define Gpm_Getch() (Gpm_Wgetch(NULL))
 
 /* libxtra.c */

--- a/src/prog/gpm-root.y
+++ b/src/prog/gpm-root.y
@@ -128,7 +128,7 @@ typedef struct DrawItem {
    char *name;
    char *arg;   /* a cmd string */
    void *clientdata;  /* a (Draw *) for menus or whatever   */
-   int (*fun)();
+   int (*fun)(int, struct DrawItem *, int);
    struct DrawItem *next;
 } DrawItem;
 
@@ -159,7 +159,7 @@ int yyerror(char *s);
 int yylex(void);
 
 DrawItem *cfg_cat(DrawItem *, DrawItem *);
-DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(), void *detail);
+DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(int,  DrawItem *, int), void *detail);
 
 
 /*===================================================================*
@@ -195,7 +195,7 @@ int f_pipe(int mode, DrawItem *self, int uid);
       char *string;
       Draw *draw;
       DrawItem *item;
-      int (*fun)();
+      int (*fun)(int,  DrawItem *, int);
       }
 
 %token <string> T_STRING
@@ -284,7 +284,7 @@ struct tokenName tokenList[] = {
 struct funcName {
    char *name;
    int token;
-   int (*fun)();
+   int (*fun)(int,  DrawItem *, int);
    };
 struct funcName funcList[] = {
    {"f.debug",T_FUNC,f_debug},
@@ -390,7 +390,7 @@ Draw *cfg_alloc(void)
 
 /*---------------------------------------------------------------------*/
 /* malloc an empty DrawItem and fill it */
-DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(), void *detail)
+DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(int,  DrawItem *, int), void *detail)
 {
    DrawItem *new=calloc(1,sizeof(DrawItem));
 
@@ -405,7 +405,7 @@ DrawItem *cfg_makeitem(int mode, char *msg, int(*fun)(), void *detail)
 
       case 'F': /* a function without args */
          new->fun=fun;
-         if (fun) fun(F_CREATE,new);
+         if (fun) fun(F_CREATE,new,0);
          break;
 
       case 'M':
@@ -1047,7 +1047,7 @@ Posted *postmenu(int fd, FILE *f, Draw *draw, int x, int y, int console)
    }
    /* sides and items */
    for (item=draw->menu; y++, item; item=item->next) {
-         if (item->fun) (*(item->fun))(F_POST,item);
+         if (item->fun) (*(item->fun))(F_POST,item,0);
          GOTO(x,y); PUTC(VERLINE,draw->bord,draw->back);
          for (i=0;i<item->pad;i++) PUTC(' ',draw->fore,draw->back);
          PUTS(item->name,draw->fore,draw->back); i+=strlen(item->name);

--- a/src/prog/gpm-root.y
+++ b/src/prog/gpm-root.y
@@ -941,7 +941,7 @@ static unsigned short clear_sel_args[6]={0, 0,0, 0,0, 4};
 static unsigned char *clear_sel_arg= (unsigned char *)clear_sel_args+1;
 
 /*------------*/
-static inline void scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
+static inline void gpm_scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
 {
    int dumpfd;
    char dumpname[20];
@@ -960,7 +960,7 @@ static inline void scr_dump(int fd, FILE *f, unsigned char *buffer, int vc)
 }
 
 /*------------*/
-static inline void scr_restore(int fd, FILE *f, unsigned char *buffer, int vc)
+static inline void gpm_scr_restore(int fd, FILE *f, unsigned char *buffer, int vc)
 {
    int dumpfd;
    char dumpname[20];
@@ -1002,7 +1002,7 @@ Posted *postmenu(int fd, FILE *f, Draw *draw, int x, int y, int console)
    if (!new) return NULL;
    new->draw=draw;
    new->dump=dump=malloc(opt_buf);
-   scr_dump(fd,f,dump,console);
+   gpm_scr_dump(fd,f,dump,console);
    lines=dump[0]; columns=dump[1];
    i=(columns*dump[3]+dump[2])*2+1; /* where to get it */
    if (i<0) i=1;
@@ -1060,7 +1060,7 @@ Posted *postmenu(int fd, FILE *f, Draw *draw, int x, int y, int console)
    for (i=0; i<draw->width; i++) PUTC(HORLINE,draw->bord,draw->back);
    PUTC(LRCORNER,draw->bord,draw->back);
 
-   scr_restore(fd,f,dump,console);
+   gpm_scr_restore(fd,f,dump,console);
    free(dump);
 
 #undef PUTC
@@ -1077,7 +1077,7 @@ Posted *unpostmenu(int fd, FILE *f, Posted *which, int vc)
 {
    Posted *prev=which->prev;
 
-   scr_restore(fd,f,which->dump, vc);
+   gpm_scr_restore(fd,f,which->dump, vc);
    ioctl(fd,TCXONC,TCOON); /* activate the console */  
    free(which->dump);
    free(which);

--- a/src/prog/hltest.c
+++ b/src/prog/hltest.c
@@ -80,7 +80,6 @@ int wid,hei,vcsize;
 unsigned short clear_sel_args[6]={0, 0,0, 0,0, 4};
 unsigned char *clear_sel_arg= (unsigned char *)clear_sel_args+1;
 
-
 static inline int scrdump(char *buf)
 {
    clear_sel_arg[0]=2;  /* clear_selection */
@@ -99,7 +98,7 @@ static inline int scrrestore(char *buf)
 
 
 /* I don't like curses, so I'm doing low level stuff here */
-static void raw(void)
+static void gpm_raw(void)
 {
 struct termios it;
 
@@ -115,7 +114,7 @@ tcsetattr(fileno(stdin),TCSANOW,&it);
 
 }
 
-static void noraw(void)
+static void gpm_noraw(void)
 {
 struct termios it;
 
@@ -136,7 +135,7 @@ void killed(int signo)
 {
    CLEAR;
    fprintf(stderr,"hltest: killed by signal %i\r\n",signo);
-   noraw();
+   gpm_noraw();
    exit(0);
 }
 
@@ -525,7 +524,7 @@ int main(int argc, char **argv)
    gpm_roi_handler=xhandler;
    gpm_roi_data=NULL;
 
-   raw();
+   gpm_raw();
    newmsg(0,NULL); /* init data structures */
    while((c=Gpm_Getchar())!=EOF) {
       char s[32];
@@ -538,6 +537,6 @@ int main(int argc, char **argv)
    newmsg(roi ? ((WinInfo *)roi->clientdata)->number : 0,s);
    }
 
-   noraw();
+   gpm_noraw();
    exit(0);
 }

--- a/src/prog/mouse-test.c
+++ b/src/prog/mouse-test.c
@@ -106,7 +106,7 @@ return 0;
 /*----------------------------------------------------------------------------- 
    Place the description here.
  -----------------------------------------------------------------------------*/
-static void raw(void)
+static void gpm_raw(void)
 {
    struct termios it;
 
@@ -125,7 +125,7 @@ static void raw(void)
 /*----------------------------------------------------------------------------- 
    Place the description here.
  -----------------------------------------------------------------------------*/
-static void noraw(void)
+static void gpm_noraw(void)
 {
    struct termios it;
 
@@ -144,7 +144,7 @@ static void noraw(void)
 void killed(int signo)
 {
    fprintf(stderr,"mouse-test: killed by signal %i\r\n",signo);
-   noraw();
+   gpm_noraw();
    exit(0);
 }
 
@@ -196,7 +196,7 @@ int mousereopen(int oldfd, const char *name, Gpm_Type *type)
 
 int noneofthem(void)
 {
-   noraw();
+   gpm_noraw();
    printf("\n\nSomething went wrong, I didn't manage to detect your"
 	 "protocol\n\nFeel free to report your problems to the author\n");
    exit(1);
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
    I_serial=mice->init; /* the first one has I_serial */
 
    signal(SIGINT,killed);   /* control-C kills us */
-   raw();
+   gpm_raw();
 
 /*====================================== First of all, detect the device */
 
@@ -568,7 +568,7 @@ int main(int argc, char **argv)
    /* why checking and not using return value ??? */
    CHECKFAIL(typecount);
    if (typecount==1) {
-      noraw();
+      gpm_noraw();
       printf("\n\n\nWell, it seems like your mouse is already detected:\n"
       "it is on the device \"%s\", and speaks the protocol \"%s\"\n",
       mousename,list->this->name);
@@ -587,7 +587,7 @@ int main(int argc, char **argv)
    } while(i!='y' && i!='n');
 
    if (i=='n') {
-      noraw();
+      gpm_noraw();
       printf("\nThen, you should use the \"bare\" protocol on \"%s\"\n",
 	   mousename);
       exit(0);
@@ -634,7 +634,7 @@ int main(int argc, char **argv)
    for (pending=0,i=0;i<got-16;i++)
       if(!memcmp(buf+i,buf+i+8,8)) pending++;
    if (pending > 3) {
-      noraw();
+      gpm_noraw();
       printf("\nYour mouse seems to be a 'mman' one  on \"%s\" (%i matches)\n",
 	   mousename,pending);
       exit(0);
@@ -660,7 +660,7 @@ int main(int argc, char **argv)
          continue;
       }
 	   if (pending>3) {
-	      noraw();
+	      gpm_noraw();
 	      printf("\nYour mouse seems to be a '%s' one on \"%s\" (%i matches)\n",
 		   cur->this->name,mousename,pending);
 	      exit(0);
@@ -695,7 +695,7 @@ int main(int argc, char **argv)
          for (pending=0,i=0;i<got-20;i++)
             if(!memcmp(buf+i,buf+i+10,10)) pending++;
          if (pending>3) {
-            noraw();
+            gpm_noraw();
             printf("\nYour mouse becomes a 3-buttons ('-t msc') one when\n"
 	         "gpm gets '-o %s' on it command line, and X gets\n"
 	         "%s in XF86Config\nThe device is \"%s\"",
@@ -726,7 +726,7 @@ int main(int argc, char **argv)
    for (pending=0,i=0;i<got-20;i++)
       if(!memcmp(buf+i,buf+i+10,10)) pending++;
    if (pending>3) {
-      noraw();
+      gpm_noraw();
       printf("\nWorked. You should keep the button pressed every time the\n"
 	   "computer boots, and run gpm in '-R' mode in order to ignore\n"
 	   "such hassle when starting X\n\nStill better, but a better mouse\n"
@@ -734,7 +734,7 @@ int main(int argc, char **argv)
 
       exit(0);
    }
-   noraw();
+   gpm_noraw();
    printf("\nI'm lost. Can't tell you how to use your middle button\n");
    return 0;
 }


### PR DESCRIPTION
Fixes errors that were warnings, once.
1. Fixes system include that fails to provide argument to function and breaks all packages using it by that.
2. Prefix gpm-specific functions with same name as function from curses with gpm_
3. Fill function definition in yacc source with correct arguments, so compiler ceases screaming about three arguments to 0-argument function. Add 0 as third argument when it's two-argument function.